### PR TITLE
Set CircleCI checkout step method to full

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ commands:
             - source-{{ .Branch }}-{{ .Revision }}
             - source-{{ .Branch }}-
             - source-
-      - checkout
+      - checkout:
+          method: full
       - save_cache:
           key: source-{{ .Branch }}-{{ .Revision }}
           paths:


### PR DESCRIPTION
CircleCI are introducing a breaking change to the checkout step where the default clone method will soon be blobless instead of full, more info [here](https://circleci.com/changelog/introducing-a-faster-checkout-option/?utm_medium=email&_hsenc=p2ANqtz-86y5jrqjfjV0Pc4FvOyMoyOlCAV-eDhwEj8ofY74xMrWX3k8cUvHY4XwkdgQxFaJNHbw4hddLdN4dQ1YLgg1D4mxN7zzkgmWJBVPnPXIZU-t2k0H8&_hsmi=384508146&utm_content=384508146&utm_source=hs_email).
This PR mitigates the breaking change by setting the checkout method to full.

If you need a full clone, approve and merge this PR.
If a blobless checkout is sufficient and you wish to benefit from the associated performance enhancements: set the method to blobless, or, close this PR and use the new default value.

This PR was generated automatically.
Feel free to reach out to me on slack (@charlotte.dodd).